### PR TITLE
Chore/gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .pnp.js
 
 # fonts 
+# opentype
 *.otf
 
 # testing


### PR DESCRIPTION
Prevent .otf font files from being pushed to remote repo.