### PR TITLE
Readjusts header font-sizes for each view width.

### DIFF
--- a/src/Pages/Contact/Contact.jsx
+++ b/src/Pages/Contact/Contact.jsx
@@ -13,12 +13,12 @@ export default function Contact() {
         >
             <div className="contact-content">
                 <h1>Let's Connect</h1>
-                <h2>Reach Out and Say Hello</h2>
+                <h2>Don't Hesitate to Reach Out</h2>
                 <article className="contact-text">
                     If you would like to get in touch, just send me an email.
                     I will get back to you as soon as possible.
-                    Additionally, you can find a link to my GitHub page for more coding topics.
-                    To learn more about my educational and professional background,
+                    You can find a link to my GitHub page for more coding topics.
+                    To learn more about my professional and educational background,
                     you can visit my LinkedIn and Xing profiles.
                 </article>
                 <Social />

--- a/src/index.css
+++ b/src/index.css
@@ -152,8 +152,8 @@ article {
   --content-width: 90vw;
   --medium-content-width: 70vw;
   --box-shadow: 2vw 2vw var(--grey-80);
-  --fs-huge: 4rem;
-  --fs-big: 2rem;
+  --fs-huge: 3rem;
+  --fs-big: 1.75rem;
   --fs-medium: 1.25rem;
   --fs-normal: 1rem;
   --fs-small: 0.75rem;
@@ -168,8 +168,8 @@ article {
   --content-width: 90vw;
   --medium-content-width: 70vw;
   --box-shadow: 2vw 2vw var(--grey-80);
-  --fs-huge: 4rem;
-  --fs-big: 2rem;
+  --fs-huge: 3.5rem;
+  --fs-big: 1.75rem;
   --fs-medium: 1.25rem;
   --fs-normal: 1rem;
   --fs-small: 0.75rem;
@@ -200,8 +200,8 @@ article {
   --content-width: 90vw;
   --medium-content-width: 70vw;
   --box-shadow: 0.75vw 0.75vw var(--grey-80);
-  --fs-huge: 5rem;
-  --fs-big: 3.5rem;
+  --fs-huge: 6rem;
+  --fs-big: 3rem;
   --fs-medium: 2rem;
   --fs-normal: 1.5rem;
   --fs-small: 1rem;
@@ -216,8 +216,8 @@ article {
   --content-width: 90vw;
   --medium-content-width: 70vw;
   --box-shadow: 0.75vw 0.75vw var(--grey-80);
-  --fs-huge: 5rem;
-  --fs-big: 3.5rem;
+  --fs-huge: 6rem;
+  --fs-big: 3rem;
   --fs-medium: 2rem;
   --fs-normal: 1.5rem;
   --fs-small: 1rem;


### PR DESCRIPTION
Some headers were overlapping the border of their containers. Adjusting the font-sizes in index.css for each view width takes care of that issue. 